### PR TITLE
Add support for negative numbers in JSON

### DIFF
--- a/Sources/Coolie.swift
+++ b/Sources/Coolie.swift
@@ -317,7 +317,7 @@ public class Coolie: NSObject {
         func scanNumber() -> Token? {
 
             let symbolSet = NSMutableCharacterSet.decimalDigitCharacterSet()
-            symbolSet.addCharactersInString(".")
+            symbolSet.addCharactersInString(".-")
 
             var string: NSString?
 


### PR DESCRIPTION
This pull request fixes an issue were Coolie will fail if the supplied JSON file contains negative numbers. 
